### PR TITLE
feat(sql): 新增app、comment、order_info、payment_info和refund_info等数据表

### DIFF
--- a/sql/lwf_nfsn_business_central_platform.sql
+++ b/sql/lwf_nfsn_business_central_platform.sql
@@ -1,0 +1,112 @@
+/*
+ Navicat Premium Data Transfer
+
+ Source Server         : AtnibamAitay
+ Source Server Type    : MySQL
+ Source Server Version : 80023
+ Source Host           : localhost:3306
+ Source Schema         : nfsn_business_central_platform
+
+ Target Server Type    : MySQL
+ Target Server Version : 80023
+ File Encoding         : 65001
+
+ Date: 29/10/2023 18:05:48
+*/
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ----------------------------
+-- Table structure for app
+-- ----------------------------
+DROP TABLE IF EXISTS `app`;
+CREATE TABLE `app`  (
+  `id` int(0) NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `app_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '应用名',
+  `status` tinyint(0) NOT NULL COMMENT '状态',
+  `payment_call_back_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '支付结果的回调地址',
+  `refund_call_back_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '退款结果的回调地址',
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 4 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci ROW_FORMAT = Dynamic;
+
+-- ----------------------------
+-- Table structure for comment
+-- ----------------------------
+DROP TABLE IF EXISTS `comment`;
+CREATE TABLE `comment`  (
+  `id` int(0) NOT NULL AUTO_INCREMENT COMMENT '评论ID',
+  `user_id` int(0) NULL DEFAULT NULL COMMENT '用户ID',
+  `object_id` int(0) NOT NULL COMMENT '对象ID（文章/视频/商品/父评论）',
+  `object_type` varchar(50) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT '对象类型（0代表文章评论、1代表视频评论、2代表商品评论、3代表评论的子评论）',
+  `content` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT '内容',
+  `type` tinyint(0) NOT NULL DEFAULT 0 COMMENT '内容类型（0代表文本，1代表表情包，2代表图片）',
+  `deleted` tinyint(0) NOT NULL DEFAULT 0 COMMENT '是否删除（0未删除，1已删除）',
+  `create_time` datetime(0) NULL DEFAULT NULL COMMENT '创建时间',
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 30 CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = Dynamic;
+
+-- ----------------------------
+-- Table structure for order_info
+-- ----------------------------
+DROP TABLE IF EXISTS `order_info`;
+CREATE TABLE `order_info`  (
+  `id` bigint(0) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '订单id',
+  `title` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '订单标题',
+  `order_no` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '平台的订单编号',
+  `user_id` bigint(0) NULL DEFAULT NULL COMMENT '用户id',
+  `product_id` bigint(0) NULL DEFAULT NULL COMMENT '支付产品id',
+  `total_fee` int(0) NULL DEFAULT NULL COMMENT '订单金额(分)',
+  `payment_data` varchar(1500) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '微信支付的订单二维码链接或者支付宝支付的HTML表单',
+  `order_status` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '订单状态',
+  `create_time` datetime(0) NULL DEFAULT CURRENT_TIMESTAMP(0) COMMENT '创建时间',
+  `update_time` datetime(0) NULL DEFAULT CURRENT_TIMESTAMP(0) ON UPDATE CURRENT_TIMESTAMP(0) COMMENT '更新时间',
+  `payment_type` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '支付方式',
+  `app_id` int(0) NULL DEFAULT NULL COMMENT 'AppID',
+  `payment_call_back_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '支付结果的回调地址',
+  `refund_call_back_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '退款结果的回调地址',
+  PRIMARY KEY (`id`) USING BTREE,
+  INDEX `idx_orderId`(`id`) USING BTREE,
+  INDEX `idx_userId`(`user_id`) USING BTREE,
+  INDEX `idx_productId`(`product_id`) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 1700176381923098805 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci ROW_FORMAT = Dynamic;
+
+-- ----------------------------
+-- Table structure for payment_info
+-- ----------------------------
+DROP TABLE IF EXISTS `payment_info`;
+CREATE TABLE `payment_info`  (
+  `id` bigint(0) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '支付记录id',
+  `order_no` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '平台的订单编号',
+  `transaction_id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '支付系统交易编号',
+  `payment_type` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '支付类型',
+  `trade_type` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '交易类型',
+  `trade_state` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '交易状态',
+  `payer_total` int(0) NULL DEFAULT NULL COMMENT '支付金额(分)',
+  `content` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL COMMENT '通知参数',
+  `create_time` datetime(0) NULL DEFAULT CURRENT_TIMESTAMP(0) COMMENT '创建时间',
+  `update_time` datetime(0) NULL DEFAULT CURRENT_TIMESTAMP(0) ON UPDATE CURRENT_TIMESTAMP(0) COMMENT '更新时间',
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 59 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci ROW_FORMAT = Dynamic;
+
+-- ----------------------------
+-- Table structure for refund_info
+-- ----------------------------
+DROP TABLE IF EXISTS `refund_info`;
+CREATE TABLE `refund_info`  (
+  `id` bigint(0) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '退款单id',
+  `order_no` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '平台的订单编号',
+  `refund_no` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '平台的退款单编号',
+  `refund_id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '支付系统退款单号',
+  `total_fee` int(0) NULL DEFAULT NULL COMMENT '原订单金额(分)',
+  `refund` int(0) NULL DEFAULT NULL COMMENT '退款金额(分)',
+  `reason` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '退款原因',
+  `refund_status` varchar(30) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '退款状态',
+  `content_return` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL COMMENT '申请退款返回参数',
+  `content_notify` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL COMMENT '退款结果通知参数',
+  `create_time` datetime(0) NULL DEFAULT CURRENT_TIMESTAMP(0) COMMENT '创建时间',
+  `update_time` datetime(0) NULL DEFAULT CURRENT_TIMESTAMP(0) ON UPDATE CURRENT_TIMESTAMP(0) COMMENT '更新时间',
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE = InnoDB AUTO_INCREMENT = 27 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci ROW_FORMAT = Dynamic;
+
+SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
将五个新的SQL脚本放置在SpringCloud的SQL目录下，这些脚本包括：
- app：应用信息表，包含应用名、状态、支付结果回调地址和退款结果回调地址等字段。
- comment：评论信息表，包含用户ID、对象ID、对象类型、内容、内容类型、是否删除和创建时间等字段。
- order_info：订单信息表，包含订单id、订单标题、平台的订单编号、用户id、支付产品id、订单金额、支付方式、订单状态、创建时间、更新时间、AppID、支付结果的回调地址和退款结果的回调地址等字段。
- payment_info：支付记录表，包含支付记录id、平台的订单编号、支付系统交易编号、支付类型、交易类型、交易状态、支付金额和通知参数等字段。
- refund_info：退款单表，包含退款单id、平台的订单编号、平台的退款单编号、支付系统退款单号、原订单金额、退款金额、退款原因、退款状态、申请退款返回参数、退款结果通知参数等字段。

这些数据表将支持我们的订单处理、评论管理、支付记录追踪和退款处理等功能。